### PR TITLE
Fixed warning regarding maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.0-SNAPSHOT</maven.version>
+    <maven.version>3.0.3</maven.version>
   </properties>
   
   <dependencies>
@@ -143,7 +143,9 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <source>1.5</source>


### PR DESCRIPTION
got rid of warnings by putting <groupId> and <version> for maven-compiler-plugin ( ~line 145 in pom.xml )
