### PR TITLE
Maven repository sonatype no longer lists 3.0 as available.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.0-SNAPSHOT</maven.version>
+    <maven.version>3.0.4-SNAPSHOT</maven.version>
   </properties>
   
   <dependencies>


### PR DESCRIPTION
Hi,

I noticed the Maven repository is no longer showing 3.0 as available, for instance,

```
https://repository.sonatype.org/content/repositories/maven.snapshots/org/apache/maven/maven-core/
```

I updated the pom.xml and build now succeeds and tests pass.

Aaron
