### PR TITLE
Updated POM with new maven version, so that it compiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>3.0-SNAPSHOT</maven.version>
+    <maven.version>3.0.4-SNAPSHOT</maven.version>
   </properties>
   
   <dependencies>


### PR DESCRIPTION
Hey, 

I made a quick update to the pom to change the maven version variable, so that it compiles. 3.0-SNAPSHOT doesn't appear to be in the repository you are using, and appears to have been replaced by 3.0.4-SNAPSHOT.
