### PR TITLE
I think using 'current' version of gvm's groovysh is more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ There has been a lot of work to rewrite malabar-mode to make it easier to mainta
 
 ```
     git clone https://github.com/alexott/cedet.git
-	make all
+    cd cedet
+    make all
 ```
 - Install malabar-mode from melpa
 


### PR DESCRIPTION
As my version is 2.4.0, I had trouble starting malabar-mode. With this change, the 'current' version is used that saves the trouble for the user to redefine it.