### PR TITLE
Fix missing `current-targets' slot in ede-malabar-maven2-project

### DIFF
--- a/src/main/lisp/malabar-ede-maven.el
+++ b/src/main/lisp/malabar-ede-maven.el
@@ -77,6 +77,7 @@
 (defclass ede-malabar-maven2-project (ede-maven2-project)
   ((tracking-symbol :initform 'ede-maven2-project-list)
    (file-header-line :initform ";; EDE Maven2 project wrapper")
+   (current-targets :initform nil :initarg :current-targets)
    (pom :initform nil
 	:initarg :pom
 	:documentation "Parsed pom.xml file")


### PR DESCRIPTION
Hi.  I was setting up malabar mode and received an error about this missing slot when trying to load Java files.  It appears to have been left out by mistake.  This fixes the immediate error, though I'm not sure of the greater context in which it's operating.

Thank you!
Sasha
