### PR TITLE
malabar-mode should depend on groovy-mode.

### DIFF
--- a/src/main/lisp/malabar-mode.el
+++ b/src/main/lisp/malabar-mode.el
@@ -8,7 +8,7 @@
 ;;     Matthew Smith <matt@m0smith.com>
 ;; URL: http://www.github.com/m0smith/malabar-mode
 ;; Version: 2.5.1
-;; Package-Requires: ((fringe-helper "1.0.1"))
+;; Package-Requires: ((fringe-helper "1.0.1") (groovy-mode "0"))
 ;; Keywords: java, maven, groovy, language, malabar
 
 ;;; License:


### PR DESCRIPTION
Since we require inf-groovy, we need inf-groovy.el to be present or
malabar-mode doesn't work.
