### PR TITLE
Enable to search ~/.sdkman and ~/.gvm for groovysh-guess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,18 @@ EMACS=emacs
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 
+#
+# CEDET_DIR=~/.emacs.d/cedet make
+#
 all: test
 
 test: test-elk test-ert
 
 test-elk:
-#	cd $(mkfile_dir) && $(EMACS) -Q --batch -l src/test/lisp/init.el -l src/test/lisp/all-tests.el
-	cd $(mkfile_dir) && $(EMACS) -Q --batch -f toggle-debug-on-error -l src/test/lisp/init.el  -l src/test/lisp/all-tests.el
+	cd $(mkfile_dir) && $(EMACS) -Q --batch \
+	-f toggle-debug-on-error \
+	-l src/test/lisp/init.el \
+	-l src/test/lisp/all-tests.el
 
 test-ert:
 	cd $(mkfile_dir) && $(EMACS) -Q --batch  -l ert -l src/test/lisp/init.el \

--- a/src/main/lisp/malabar-reflection.el
+++ b/src/main/lisp/malabar-reflection.el
@@ -132,7 +132,7 @@
   "Get the project info for a project file"
   (interactive (list
 		(completing-read "Project Manager: " malabar-known-project-managers nil nil nil nil malabar-mode-project-manager)
-		(read-file-name  "Project file (pom, build.gradle):")))
+		(read-file-name  "Project file (pom.xml, build.gradle):")))
   (let ((pmfile (or pmfile malabar-mode-project-file))
 	(pm (or pm malabar-mode-project-manager))
 	(repo (or repo (expand-file-name malabar-package-maven-repo))))

--- a/src/main/lisp/malabar-variables.el
+++ b/src/main/lisp/malabar-variables.el
@@ -92,9 +92,17 @@ smallest"
 			       'version-to-list
 			       (--mapcat (last (split-string it "[/]")) files)))))
 
+(defun malabar-groovy-directories ()
+  (append 
+   (if (file-directory-p "~/.sdkman/groovy")
+       (directory-files "~/.sdkman/groovy" t "[0-9]$"))
+   (if (file-directory-p "~/.gvm/groovy")
+       (directory-files "~/.gvm/groovy" t "[0-9]$")))  
+  )
+
 (defun malabar-repl-groovysh-guess* ()
   (let ((execs '("bin/groovysh" "bin/groovysh.bat"))
-	(version-dirs (sort  (directory-files "~/.gvm/groovy" t "[0-9]$") 'malabar-groovysh-version-dir->)))
+	(version-dirs (sort (malabar-groovy-directories) 'malabar-groovysh-version-dir->)))
     (car
      (-filter 'file-executable-p
 	      (-table-flat 'expand-file-name execs version-dirs)))))

--- a/src/test/lisp/init.el
+++ b/src/test/lisp/init.el
@@ -1,4 +1,9 @@
 (require 'package)
 (package-initialize)
 
-(load-file "~/projects/cedet/cedet-devel-load.el")
+(setq cedet_dir (getenv "CEDET_DIR"))
+
+(if (null cedet_dir)
+    (load-file "~/projects/cedet/cedet-devel-load.el")
+  (load-file (concat (file-name-as-directory cedet_dir) "cedet-devel-load.el"))
+)


### PR DESCRIPTION
- Enable to search `~/.sdkman` and `~/.gvm` for groovysh-guess
  - Because `gvm` updated `sdkman`
  - I don't familiar with groovy, please review behavior.
- Enable to specify cedet src directory when a user build it
