### PR TITLE
Fix gradle integration

### DIFF
--- a/src/main/lisp/malabar-ede-gradle.el
+++ b/src/main/lisp/malabar-ede-gradle.el
@@ -207,7 +207,7 @@
 (ede-add-project-autoload
  (ede-project-autoload "malabar-gradle"
 		       :name "MALABAR GRADLE"
-		       :file 'ede/gradle
+		       :file 'malabar-ede-gradle
 		       :proj-file  "build.gradle"
 		       :load-type 'malabar-gradle-load
 		       :class-sym 'ede-malabar-gradle-project

--- a/src/main/lisp/malabar-ede-gradle.el
+++ b/src/main/lisp/malabar-ede-gradle.el
@@ -42,6 +42,9 @@
 (require 'malabar-project)
 (require 'malabar-reflection)
 
+(defvar ede-gradle-project-list nil
+  "List of projects created by option `ede-gradle'.")
+
 (defun malabar-gradle-extract-classpath (pom-file)
   (interactive "DProject dir:")
   (let ((pi (malabar-project-info "gradle" pom-file)))

--- a/src/main/lisp/malabar-ede-gradle.el
+++ b/src/main/lisp/malabar-ede-gradle.el
@@ -203,12 +203,16 @@
        (setq malabar-mode-project-manager "gradle"))
      rtnval))
 
+(defun ede-malabar-project-root (&optional dir)
+  "Get the root directory for DIR."
+  (ede-find-project-root "build.gradle" dir))
 
 (ede-add-project-autoload
  (ede-project-autoload "malabar-gradle"
 		       :name "MALABAR GRADLE"
 		       :file 'malabar-ede-gradle
 		       :proj-file  "build.gradle"
+		       :proj-root 'ede-malabar-project-root
 		       :load-type 'malabar-gradle-load
 		       :class-sym 'ede-malabar-gradle-project
 		       :new-p nil

--- a/src/main/lisp/malabar-mode.el
+++ b/src/main/lisp/malabar-mode.el
@@ -1712,10 +1712,13 @@ current buffer.  Also set the server logging level to FINEST.  See the *groovy* 
     (easy-menu-add-item nil '("Development") malabar-mode-menu-map "JVM")
     
     (let* ((project-instance (ede-current-project))
-	   (project-file (oref  project-instance file))
-	   (project-dir (file-name-directory project-file)))
+           (project-manager (if (eq (eieio-object-class (ede-current-project)) 'ede-malabar-gradle-project)
+                                "gradle"
+                              "maven"))
+           (project-file (oref  project-instance file))
+           (project-dir (file-name-directory project-file)))
       (setq malabar-mode-project-dir project-dir )
-      (setq malabar-mode-project-manager "maven" )
+      (setq malabar-mode-project-manager project-manager)
       (setq malabar-mode-project-file project-file)
       (setq malabar-mode-project-name (file-name-nondirectory (directory-file-name project-dir))))
     

--- a/src/main/lisp/malabar-mode.el
+++ b/src/main/lisp/malabar-mode.el
@@ -56,7 +56,7 @@
 (require 'malabar-reflection)
 (require 'malabar-http)
 ;(require 'malabar-ede-maven)
-;(require 'malabar-ede-gradle)
+(require 'malabar-ede-gradle)
 (require 'malabar-mode-autoloads)
 
 

--- a/src/main/lisp/malabar-util.el
+++ b/src/main/lisp/malabar-util.el
@@ -18,7 +18,7 @@
 ;; 02110-1301 USA.
 ;;
 (require 'cl)
-;(require 'semantic)
+(require 'semantic/find)
 
 
 ;; (defun malabar-util-expand-file-name (f &optional DEFAULT-DIRECTORY)


### PR DESCRIPTION
Fixes:
- Add missing ede-gradle-project-list var
- Add an ede proj-root function for gradle
- Set malabar-mode-project-manager to "gradle" if the current ede project is a gradle project.
- Add require 'semantic/find so semantic-find-tags-by-class macro is known at compile time. Solves https://github.com/m0smith/malabar-mode/issues/165
