### PR TITLE
README Typo: Corrected "monir-mode" to "minor-mode."

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 EMACS integration with the JVM.
 
 
-malabar-mode is a monir-mode with hooks into Maven that makes
+malabar-mode is a minor-mode with hooks into Maven that makes
 it easy to compile files on the fly and execute Maven build
 commands.
 


### PR DESCRIPTION
Tiny typo in the README.
